### PR TITLE
Remove buffering before encryption (#1)

### DIFF
--- a/lib/zip-crypto-stream.js
+++ b/lib/zip-crypto-stream.js
@@ -76,11 +76,7 @@ ZipCryptoStream.prototype._smartStream = function(ae, callback) {
     : new CRC32Stream();
   var error = null;
 
-  var buffer = Buffer.alloc(0);
   function handleStuff() {
-    buffer = zipCrypto.encrypt(buffer);
-    this.write(buffer);
-    buffer = Buffer.alloc(0);
     var digest = process.digest().readUInt32BE(0);
     ae.setCrc(digest);
     ae.setSize(process.size());
@@ -90,9 +86,10 @@ ZipCryptoStream.prototype._smartStream = function(ae, callback) {
   }
   var outStream = new Writable({
     write: function(chunk, encoding, callback) {
-      buffer = Buffer.concat([buffer, chunk]);
+      var buffer = zipCrypto.encrypt(chunk);
+      this.write(buffer);
       callback();
-    }
+    }.bind(this)
   });
 
   process.once('end', handleStuff.bind(this));


### PR DESCRIPTION
Encrypting data after reading the entire content of large files causes network timeout when using AWS S3 stream.
This buffering is not necessary and should be deleted.