### PR TITLE
Fix that files without compression cannot be unzipped (#8)

### DIFF
--- a/lib/zip-crypto-stream.js
+++ b/lib/zip-crypto-stream.js
@@ -50,43 +50,32 @@ ZipCryptoStream.prototype.finalize = function() {
 
 ZipCryptoStream.prototype._appendBuffer = function(ae, source, callback) {
   ae.gpb.useEncryption(true);
-  ZipStream.prototype._appendBuffer.call(this, ae, source, callback);
+  // Use data descriptor whatever the method is,
+  // because when using encryption, we need to calculate
+  // the compressed size with encrypted data.
+  ae.gpb.useDataDescriptor(true);
+  ae.setVersionNeededToExtract(constants.MIN_VERSION_DATA_DESCRIPTOR);
+
+  if (source.length === 0) {
+    ae.setMethod(constants.METHOD_STORED);
+  }
+
+  this._writeLocalFileHeader(ae);
+
+  var method = ae.getMethod();
+  if (
+    method === constants.METHOD_STORED ||
+    method === constants.METHOD_DEFLATED
+  ) {
+    this._smartStream(ae, callback).end(source);
+  } else {
+    callback(new Error('compression method ' + method + ' not implemented'));
+  }
 };
 
 ZipCryptoStream.prototype._appendStream = function(ae, source, callback) {
   ae.gpb.useEncryption(true);
   ZipStream.prototype._appendStream.call(this, ae, source, callback);
-};
-
-ZipCryptoStream.prototype._writeLocalFileHeader = function(ae) {
-  // When the source length is zero, ZipArchiveOutputStream._appendBuffer()
-  // sets the encryption method to STORED and _smartStream() is not called.
-  // To write encryption header and append its size to the compressed size,
-  // create encryption header here only when the source length is zero
-  // and the encryption method to STORED.
-  var encryptionHeader;
-  if (ae.getMethod() === constants.METHOD_STORED && ae.getSize() == 0) {
-    // If the data descriptor bit is not set in the general purpose bits,
-    // compressed size must be written when writing local file header,
-    // so set the encryption header size to it here.
-    encryptionHeader = Buffer.from(cryptoRandomString(24), 'hex');
-    ae.setCompressedSize(encryptionHeader.length);
-  }
-
-  ZipStream.prototype._writeLocalFileHeader.call(this, ae);
-
-  // The encryption header must be written after the local file header.
-  if (ae.getMethod() === constants.METHOD_STORED && ae.getSize() == 0) {
-    var zipCrypto = new ZipCrypto(this.options);
-    zipCrypto.init();
-    var encryptedHeader = zipCrypto.encrypt(encryptionHeader);
-    var crc = ae.getTimeDos();
-    encryptedHeader[10] = crc & 0xff;
-    encryptedHeader[11] = (crc >> 8) & 0xff;
-    zipCrypto.init();
-    var encryptedHeader2 = zipCrypto.encrypt(encryptedHeader);
-    this.write(encryptedHeader2);
-  }
 };
 
 ZipCryptoStream.prototype._smartStream = function(ae, callback) {


### PR DESCRIPTION
Related: #6 

When the compression level is 0, zip-stream sets the compression method to 0 (stored),
which causes the issue for appending buffer.
When using encryption, we need to use data descriptor to use encrypted data size
for calculating compressed size.
In this fix, `ZipCryptoStream._writeLocalFileHeader()` is removed and
encryption is integrated to `ZipCryptoStream._smartStream()`.