### PR TITLE
Update Node versions on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ branches:
     - master
     - "/^v?[0-9\\.]+/"
 node_js:
+  - '16'
+  - '14'
   - '12'
-  - '10'
-  - '8'
 before_install:
   - 'npm install -g npm@latest'
 after_success:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,9 +5,9 @@ branches:
 
 environment:
   matrix:
+    - nodejs_version: '16'
+    - nodejs_version: '14'
     - nodejs_version: '12'
-    - nodejs_version: '10'
-    - nodejs_version: '8'
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ branches:
 
 environment:
   matrix:
-    - nodejs_version: 'latest'
+    - nodejs_version: 'Current'
     - nodejs_version: '14'
     - nodejs_version: '12'
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ branches:
 
 environment:
   matrix:
-    - nodejs_version: '16'
+    - nodejs_version: 'latest'
     - nodejs_version: '14'
     - nodejs_version: '12'
 
@@ -13,7 +13,6 @@ install:
   - ps: Install-Product node $env:nodejs_version
   - npm install -g npm@latest
   - npm install
-
 version: '{build}'
 
 shallow_clone: true


### PR DESCRIPTION
Updated Node.js versions on CI because the latest npm (v7) does not work with Node.js v8.

AppVeyor does not support Node.js v16 yet, so use 'Current' alias (v15).
I will handle [test failure on Node.js v15](https://ci.appveyor.com/project/ksoichiro/node-archiver-zip-encryptable/build/job/56p63o0y0wui6k0g) issue in a separate pull request.